### PR TITLE
Fix getDiffsWithoutText 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "org.jetbrains.research.ictl"
-version = "0.0.2"
+version = "0.0.3"
 
 repositories {
   mavenCentral()

--- a/src/main/kotlin/org/jetbrains/research/ictl/riskypatterns/jgit/CommitsProvider.kt
+++ b/src/main/kotlin/org/jetbrains/research/ictl/riskypatterns/jgit/CommitsProvider.kt
@@ -86,8 +86,8 @@ class CommitsProvider(private val repository: Repository, private val dayGap: Lo
 
       val treeWalk = TreeWalk(repository)
       treeWalk.isRecursive = true
-      treeWalk.addTree(newTreeIter)
       treeWalk.addTree(oldTreeIter)
+      treeWalk.addTree(newTreeIter)
 
       val diffFormatter = getDiffFormatter(repository)
       return diffFormatter.scan(oldTreeIter, newTreeIter)


### PR DESCRIPTION
It seems it doesn't effect on the results in our case, but it's not a right usage of TreeWalk